### PR TITLE
fix: three critical bugs (infinite recursion, wrong super args, empty search results)

### DIFF
--- a/dreamer/loading/funcs/meijerG_fmt.py
+++ b/dreamer/loading/funcs/meijerG_fmt.py
@@ -26,7 +26,6 @@ class MeijerG(Formatter):
         :param selected_start_points: Optional list of start points to extract shards from.
         :param only_selected: If True, only extract shards from the selected start points.
         """
-        super().__init__(const, use_inv_t)
         self.m = m
         self.n = n
         self.p = p
@@ -36,15 +35,14 @@ class MeijerG(Formatter):
         if self.shifts is None:
             self.shifts = [0] * (self.p + self.q)
 
+        super().__init__(const, self.shifts, selected_start_points, only_selected, use_inv_t)
+
         if self.p <= 0 or self.q <= 0:
             raise ValueError("Non-positive values")
         if not isinstance(self.shifts, list) and not isinstance(self.shifts, Position):
             raise ValueError("Shifts should be a list or Position")
         if self.p + self.q != len(self.shifts) and len(self.shifts) != 0:
             raise ValueError("Shifts should be of length p + q or 0")
-        self.selected_start_points = selected_start_points
-        self.only_selected = only_selected
-        self.use_inv_t = use_inv_t
 
     @classmethod
     def _from_json_obj(cls, data: dict | list) -> "MeijerG":

--- a/dreamer/search/searchers/searcher_v1/searcher_mod.py
+++ b/dreamer/search/searchers/searcher_v1/searcher_mod.py
@@ -64,5 +64,6 @@ class SearcherModV1(SearcherModScheme):
                 else:
                     filename = "".join(c if c.isalnum() or c in ('-', '_') else '_' for c in repr(space.cmf)).strip('_')
                 write_chunk(res, filename)
+                dms[space] = res
 
         return dms

--- a/dreamer/utils/constants/constant.py
+++ b/dreamer/utils/constants/constant.py
@@ -25,23 +25,24 @@ class Constant:
         self.name = name
         self.value_sympy = value_sympy
 
-        if value_mpmath:
-            self.value_mpmath = value_mpmath
+        # Store explicit mpmath value; if not given, the cached_property below
+        # will compute it lazily from the sympy expression.
+        if value_mpmath is not None:
+            self._explicit_mpmath = value_mpmath
         Constant.registry[self.name] = self
 
     @cached_property
     def value_mpmath(self):
         """
-        :return: The mpmath object representing the constnat
+        :return: The mpmath value of the constant (computed once and cached).
         """
-        if self.value_mpmath:
-            return self.value_mpmath
-        else:
-            try:
-                return sp.lambdify([], self.value_sympy, modules=['mpmath'])()
-            except Exception as e:
-                print(f"Warning: Could not auto-convert {self.name} to mpmath. Error: {e}")
-                return mp.mpf(0)
+        if hasattr(self, '_explicit_mpmath'):
+            return self._explicit_mpmath
+        try:
+            return sp.lambdify([], self.value_sympy, modules=['mpmath'])()
+        except Exception as e:
+            print(f"Warning: Could not auto-convert {self.name} to mpmath. Error: {e}")
+            return mp.mpf(0)
 
     def __mul__(self, other):
         if isinstance(other, Constant):


### PR DESCRIPTION
## Summary

Fixes three critical bugs found during code audit:

### 1. `Constant.value_mpmath` infinite recursion (`constant.py`)
The `@cached_property` method called `self.value_mpmath` recursively. Fixed by using `_explicit_mpmath` backing field.

### 2. `MeijerG.__init__` wrong `super()` argument order (`meijerG_fmt.py`)
`super().__init__(const, use_inv_t)` passed `use_inv_t` (a bool) as the `shifts` parameter. Fixed to pass all arguments in correct positional order.

### 3. `SearcherModV1.execute()` returns empty dict (`searcher_mod.py`)
The `dms` dict was initialized empty and never populated with results. Added `dms[space] = res` after `write_chunk()`.

## Testing
All fixes verified against existing test suite. New targeted tests are in PR `test/core-modules`.