### PR TITLE
fix: remove duplicate file handler in logger

### DIFF
--- a/dreamer/utils/logger.py
+++ b/dreamer/utils/logger.py
@@ -178,14 +178,9 @@ console_handler.setLevel(logging.INFO)
 console_handler.setFormatter(ColorConsoleFormatter("%(message)s"))
 sys_logger.addHandler(console_handler)
 
-# log file handler
-should_roll_over = os.path.isfile(logging_config.LOG_FILENAME)
+# log file handler — mode='w' truncates any previous log on startup;
+# subsequent writes append within the same process.
 file_handler = logging.FileHandler(logging_config.LOG_FILENAME, mode='w')
-file_handler.setLevel(logging.DEBUG)
-file_formatter = logging.Formatter('%(asctime)s | %(levelname)-8s | %(filename)s:%(funcName)s | %(message)s')
-file_handler.setFormatter(file_formatter)
-
-file_handler = logging.FileHandler(logging_config.LOG_FILENAME, mode='a')
 file_handler.setLevel(logging.DEBUG)
 file_formatter = logging.Formatter('%(asctime)s | %(levelname)-8s | %(filename)s:%(funcName)s | %(message)s')
 file_handler.setFormatter(file_formatter)


### PR DESCRIPTION
## Summary

Fixes a bug in `dreamer/utils/logger.py` where two `FileHandler` objects were created:
1. First handler created with `mode='w'`
2. Immediately reassigned to a new handler with `mode='a'` (the first was leaked)

Simplified to a single `FileHandler(mode='w')` which is the intended behavior (fresh log on each run).