### PR TITLE
Fix importing bugs

### DIFF
--- a/dreamer/system/system.py
+++ b/dreamer/system/system.py
@@ -17,10 +17,10 @@ from dreamer.utils.storage import Exporter, Importer, Formats
 from dreamer.utils.types import CMFData
 from dreamer.utils.logger import Logger
 from dreamer.utils.constants.constant import Constant
-from dreamer.configs import config
+from dreamer.configs.system import sys_config
+from dreamer.configs.extraction import extraction_config
 
-sys_config = config.system
-extraction_config = config.extraction
+
 constant_type = Union[Constant, str]
 
 


### PR DESCRIPTION
We predefined import renaming of classes in the `system.py` file causing configuration unchanged errors.